### PR TITLE
Google Analytics enabled

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -428,10 +428,10 @@ enableEmoji = true
 
   # LoveIt NEW | 0.2.0 Analytics config
   [params.analytics]
-    enable = false
+    enable = true
     # Google Analytics
     [params.analytics.google]
-      id = ""
+      id = "UA-170037159-1"
       # whether to anonymize IP
       anonymizeIP = true
     # Fathom Analytics


### PR DESCRIPTION
Enabling Google Analytics.
Preview should be displayed on the comments with the Netlify bot.